### PR TITLE
Fix handling of less common abbreviated commit hash lengths

### DIFF
--- a/utils/version.py
+++ b/utils/version.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from itertools import chain
 
 _VERSION_REGEX = re.compile(
-    r"^v(?P<version>.+)-(?P<distance>\d+)-g(?P<commit>[0-9a-f]{7})(-(?P<dirty>dirty))?$",
+    r"^v(?P<version>.+)-(?P<distance>\d+)-g(?P<commit>[0-9a-f]+)(-(?P<dirty>dirty))?$",
 )
 
 


### PR DESCRIPTION
Although `git describe` usually uses seven digits for abbreviated commit hashes in the output, the number of digits can vary (e.g. large repositories). This relaxes the regex used to parse the output to allow for this.