### PR TITLE
Add support for year placeholder in version template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/pre-build.py
+++ b/pre-build.py
@@ -9,12 +9,21 @@ def main():
     with open("version.h.template", "r", encoding="utf-8") as file:
         template = file.read()
 
-    contents_to_write = template.replace(
-        "${{ Date }}",
-        date.today().strftime("%#d %B %Y"),
-    ).replace(
-        "${{ Version }}",
-        str(version),
+    today = date.today()
+
+    contents_to_write = (
+        template.replace(
+            "${{ Date }}",
+            today.strftime("%#d %B %Y"),
+        )
+        .replace(
+            "${{ Year }}",
+            str(today.year),
+        )
+        .replace(
+            "${{ Version }}",
+            str(version),
+        )
     )
 
     with open("version.h", "w", encoding="utf-8") as file:


### PR DESCRIPTION
This adds support for replacing `${{ Year }}` in `version.h.template` with the current year when the pre-build script runs.