### PR TITLE
Replace Flake8, Black and isort pre-commit hooks with Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-# W504: Line break occurred after a binary operator
-extend-select = W504
-max-line-length = 99

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,19 +6,12 @@ repos:
       - id: end-of-file-fixer
       - id: check-json
       - id: check-yaml
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.4
     hooks:
-      - id: flake8
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--filter-files"]
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:

--- a/pre-build.py
+++ b/pre-build.py
@@ -6,7 +6,7 @@ from utils.version import get_version
 def main():
     version = get_version()
 
-    with open("version.h.template", "r", encoding="utf-8") as file:
+    with open("version.h.template", encoding="utf-8") as file:
         template = file.read()
 
     today = date.today()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
-[tool.isort]
-profile = "black"
-extra_standard_library = ["tomllib"]
+[project]
+requires-python = ">=3.11"
+
+[tool.ruff.lint]
+extend-select = ["B0", "I", "SIM", "UP"]
+extend-ignore = ["SIM112"]
+
+[tool.ruff.lint.isort]
+split-on-trailing-comma=false


### PR DESCRIPTION
This replaces the Flake8, Black and isort pre-commit hooks with Ruff.