### PR TITLE
Improve build release package script

### DIFF
--- a/build-release-package.py
+++ b/build-release-package.py
@@ -14,7 +14,11 @@ BUILD_CONFIG_FILE_NAME = "build-config.toml"
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--no-symstore", action="store_true")
+parser.add_argument(
+    "--symstore",
+    choices=["silent", "skip", "prompt"],
+    default="silent",
+)
 parser.add_argument("--msbuild-extra-args", default="")
 
 
@@ -139,7 +143,15 @@ def main():
         use_lzma=True,
     )
 
-    if args.no_symstore:
+    skip_symstore = args.symstore == "skip"
+
+    if args.symstore == "prompt":
+        user_input = input(
+            "Do you want to add the generated symbols to the symbol store? (y/n): "
+        )
+        skip_symstore = user_input.strip().lower() != "y"
+
+    if skip_symstore:
         print("Skipping update of symbol store...")
         print("Done!")
         return

--- a/build-release-package.py
+++ b/build-release-package.py
@@ -15,15 +15,17 @@ BUILD_CONFIG_FILE_NAME = "build-config.toml"
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--no-symstore", action="store_true")
+parser.add_argument("--msbuild-extra-args", default="")
 
 
-def build(msbuild_path, platform, solution_path):
+def build(msbuild_path, msbuild_extra_args, platform, solution_path):
     root_dir = get_root_dir()
     subprocess.run(
         [
             msbuild_path,
             "/m",
             f"/p:Configuration=Release;Platform={platform}",
+            msbuild_extra_args,
             "/t:Rebuild",
             root_dir / solution_path,
         ],
@@ -89,8 +91,8 @@ def main():
     if not msbuild_path:
         raise FileNotFoundError("MSBuild could not be found")
 
-    build(msbuild_path, "Win32", solution_path)
-    build(msbuild_path, "x64", solution_path)
+    build(msbuild_path, args.msbuild_extra_args, "Win32", solution_path)
+    build(msbuild_path, args.msbuild_extra_args, "x64", solution_path)
 
     Path(root_dir / output_path).mkdir(exist_ok=True)
 


### PR DESCRIPTION
This updates `build-release-package.py` to:

- add a new `--msbuild-extra-args <args>` argument to specify extra arguments to pass to MSBuild
- replace `--no-symstore` with `--symstore {silent,skip,prompt}`